### PR TITLE
Fixed data bits issue

### DIFF
--- a/alphasign/interfaces/local.py
+++ b/alphasign/interfaces/local.py
@@ -28,7 +28,7 @@ class Serial(base.BaseInterface):
                                baudrate=4800,
                                parity=serial.PARITY_EVEN,
                                stopbits=serial.STOPBITS_TWO,
-                               bytesize=7,
+                               bytesize=serial.SEVENBITS,
                                timeout=1,
                                xonxoff=0,
                                rtscts=0)


### PR DESCRIPTION
I downloaded this module to interact with my Alpha Big Dot sign. However, none of the commands worked. When I looked into the official documentation, it says that a 2 stop bit, even parity packet calls for 7 data bits per byte. serial.Serial defaults to 8. Fixed.
