### PR TITLE
Fixed allocate inserting lowercase hex characters for the size

### DIFF
--- a/alphasign/interfaces/base.py
+++ b/alphasign/interfaces/base.py
@@ -74,7 +74,7 @@ class BaseInterface(object):
     """
     seq = ""
     for obj in files:
-      size_hex = "%04x" % obj.size
+      size_hex = "%04X" % obj.size
       # format: FTPSIZEQQQQ
 
       if type(obj) == alphasign.string.String:
@@ -100,7 +100,7 @@ class BaseInterface(object):
                    ("%d" % (i + 1),
                    "A",    # file type
                    constants.UNLOCKED,
-                   "%04x" % 100,
+                   "%04X" % 100,
                    "FEFE"))
       seq += alloc_str
 


### PR DESCRIPTION
There is a major bug in the allocation code. Currently, the code translates the size field of Text and String objects (and, in the future, Dots objects) using `'%04x'`, which translates into _lowercase_ hex characters, which are rejected by the sign. This commit changes the translation strings to `'%04X'`, which makes them uppercase.
